### PR TITLE
Implement conventional CORDIC using floating point

### DIFF
--- a/src/cordic.c
+++ b/src/cordic.c
@@ -1,0 +1,69 @@
+#include <math.h>
+#include <stdio.h>
+#include "cordic.h"
+
+#define MAX_ITER 15
+#define PI 3.141592654
+
+/*
+ * compute_factor - Compute the scale factor 
+ *
+ * @n: the maximum iteration of CORDIC
+ */
+float compute_factor(int n) {
+    float k = 1.0;
+    
+    for(int i = 0; i < n; i++)
+    {
+        k /= sqrtf(1.0 + powf(2, -2*i));
+    }
+    
+    return k;
+}
+
+float conv_sincos(float theta, float *x, float *y) {
+    float sum_angle, temp;
+
+    sum_angle = 0.0;
+    *x = compute_factor(MAX_ITER);
+    *y = 0.0;
+
+    theta = fmod(theta, 360.0);
+
+    for(int i = 0; i < MAX_ITER; i++)
+    {
+        temp = *x;
+        if(sum_angle < theta)
+        {
+            /* Rotate counterclockwise*/
+            *x -= powf(2, -i) * *y;
+            *y += powf(2, -i) * temp;
+            sum_angle += atanf(powf(2, -i)) * 180.0 / PI;
+        }
+        else
+        {
+            /* Rotate clockwise */
+            *x += powf(2, -i) * *y;
+            *y -= powf(2, -i) * temp;
+            sum_angle -= atanf(powf(2, -i)) * 180.0 / PI;
+        }
+    }
+
+    return 0;
+}
+
+float conv_sin(float theta) {
+    float x, y;
+
+    conv_sincos(theta, &x, &y);
+
+    return y;
+}
+
+float conv_cos(float theta) {
+    float x, y;
+
+    conv_sincos(theta, &x, &y);
+
+    return x;
+}

--- a/src/cordic.h
+++ b/src/cordic.h
@@ -10,6 +10,9 @@ typedef int32_t fixed_t;
 #define FIXED_INTEGER_BITS 23
 #define FIXED_FRACTION_BITS 8
 
+#define MAX_ITER 15
+#define PI 3.141592654
+
 /*
  * CORDIC algorithms
  */
@@ -23,7 +26,7 @@ typedef int32_t fixed_t;
  */
 float conv_sin(float theta);
 float conv_cos(float theta);
-float conv_sincos(float theta);
+float conv_sincos(float theta, float *x, float *y);
 float conv_tan(float theta);
 
 /*

--- a/src/cordic.h
+++ b/src/cordic.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2024 Yan-Jie, Chen
  */
+#include <stdint.h>
 
 typedef int32_t fixed_t;
 

--- a/test/test_conv.c
+++ b/test/test_conv.c
@@ -1,0 +1,19 @@
+#include "cordic.h"
+#include <math.h>
+#include <stdio.h>
+
+int main()
+{
+    float x ,y;
+    
+    printf("Trig degree: CORDIC, math.h\n");
+    for(float i = 0; i < 91; i++)
+    {
+        x = conv_cos(i);
+        y = conv_sin(i);
+        printf("cos %-3.f degree: %-10.6f, %-10.6f\n", i, x, cosf(i*PI/180.0));
+        printf("sin %-3.f degree: %-10.6f, %-10.6f\n\n", i, y, sinf(i*PI/180.0));
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
`conv_sincos(theta, *x, *y)` implements the traditional CORDIC algorithm using
floating-point data types.

It uses `atanf()` to calculate the micro-angles.

There are two pointers, `x` and `y`, pointing to the values of `cos(theta)` and
`sin(theta)` respectively, where `theta` is in degrees.

By calling `conv_sincos()`, the trigonometric values such as cos and sin can be obtained.

see issue #2 